### PR TITLE
Namespace separator is now customizable instead of being hard-coded as "."

### DIFF
--- a/angular.namespacer.js
+++ b/angular.namespacer.js
@@ -13,7 +13,7 @@
   angular.module = function(name) {
     var moduleInstance = _module.apply(angular, arguments);
     var useNamespace = false;
-    var delim = '.';
+    var delimeter = '.';
     
     moduleInstance.namespace = function(flag, delim) {
       if (typeof flag === 'boolean') {
@@ -34,7 +34,7 @@
         var args = slice.call(arguments);
       
         if (useNamespace) {
-          args[0] = name + delim + providerName;
+          args[0] = name + delimeter + providerName;
         }
 
         return _method.apply(moduleInstance, args);


### PR DESCRIPTION
Namespace separator is now customizable instead of being hard-coded as "."

Those of us who use ng-annotate can now use angular namespacer, since we can set the delimeter to a character that is allowed to appear in variable names (e.g. "_")
